### PR TITLE
Added return types

### DIFF
--- a/php-rrule/RRule.php
+++ b/php-rrule/RRule.php
@@ -1005,7 +1005,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function rewind()
+	public function rewind(): void
 	{
 		$this->current = $this->iterate(true);
 		$this->key = 0;
@@ -1014,7 +1014,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function current()
+	public function current(): mixed
 	{
 		return $this->current;
 	}
@@ -1022,7 +1022,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function key()
+	public function key(): mixed
 	{
 		return $this->key;
 	}
@@ -1030,7 +1030,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function next()
+	public function next(): void
 	{
 		$this->current = $this->iterate();
 		$this->key += 1;
@@ -1039,7 +1039,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function valid()
+	public function valid(): bool
 	{
 		return $this->current !== null;
 	}
@@ -1050,7 +1050,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -1058,7 +1058,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		if ( ! is_numeric($offset) || $offset < 0 || is_float($offset) ) {
 			throw new \InvalidArgumentException('Illegal offset type: '.gettype($offset));
@@ -1090,7 +1090,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new \LogicException('Setting a Date in a RRule is not supported');
 	}
@@ -1098,7 +1098,7 @@ class RRule implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new \LogicException('Unsetting a Date in a RRule is not supported');
 	}
@@ -1113,7 +1113,7 @@ class RRule implements RRuleInterface
 	 *
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		if ( $this->isInfinite() ) {
 			throw new \LogicException('Cannot count an infinite recurrence rule.');

--- a/php-rrule/RSet.php
+++ b/php-rrule/RSet.php
@@ -456,7 +456,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function rewind()
+	public function rewind(): void
 	{
 		$this->current = $this->iterate(true);
 		$this->key = 0;
@@ -465,7 +465,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function current()
+	public function current(): mixed
 	{
 		return $this->current;
 	}
@@ -473,7 +473,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function key()
+	public function key(): mixed
 	{
 		return $this->key;
 	}
@@ -481,7 +481,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function next()
+	public function next(): void
 	{
 		$this->current = $this->iterate();
 		$this->key += 1;
@@ -490,7 +490,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function valid()
+	public function valid(): bool
 	{
 		return $this->current !== null;
 	}
@@ -501,7 +501,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetExists($offset)
+	public function offsetExists($offset): bool
 	{
 		return is_numeric($offset) && $offset >= 0 && ! is_float($offset) && $offset < count($this);
 	}
@@ -509,7 +509,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetGet($offset)
+	public function offsetGet($offset): mixed
 	{
 		if ( ! is_numeric($offset) || $offset < 0 || is_float($offset) ) {
 			throw new \InvalidArgumentException('Illegal offset type: '.gettype($offset));
@@ -541,7 +541,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetSet($offset, $value)
+	public function offsetSet($offset, $value): void
 	{
 		throw new \LogicException('Setting a Date in a RSet is not supported (use addDate)');
 	}
@@ -549,7 +549,7 @@ class RSet implements RRuleInterface
 	/**
 	 * @internal
 	 */
-	public function offsetUnset($offset)
+	public function offsetUnset($offset): void
 	{
 		throw new \LogicException('Unsetting a Date in a RSet is not supported (use addDate)');
 	}
@@ -563,7 +563,7 @@ class RSet implements RRuleInterface
 	 * introduces a performance penality.
 	 * @return int
 	 */
-	public function count()
+	public function count(): int
 	{
 		if ( $this->isInfinite() ) {
 			throw new \LogicException('Cannot count an infinite recurrence set.');


### PR DESCRIPTION
In PHP 8.1, I've started seeing deprecations like
```
Deprecated: Return type of RRule\RSet::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in wp-content/plugins/church-theme-content/includes/libraries/ct-recurrence/php-rrule/RSet.php on line 468
```

After looking at https://stackoverflow.com/q/71133749/4093019, I've added the return types.